### PR TITLE
RingStream entries handled incorrectly due to a C undefined behaviour

### DIFF
--- a/src/generic.c
+++ b/src/generic.c
@@ -223,22 +223,22 @@ HPnow (void)
  *
  * Returns the hash of the string.
  ***************************************************************************/
-int64_t
-FVNhash64 (char *str)
+uint64_t
+FVNhash64 (const char *str)
 {
-  unsigned char *s = (unsigned char *)str; /* unsigned string */
+  const unsigned char *s = (const unsigned char *)str; /* unsigned string */
 
   /* Seed hash value with FVN1_64_INIT */
-  int64_t hval = (int64_t)0xcbf29ce484222325ULL;
+  uint64_t hval = (uint64_t)0xcbf29ce484222325ULL;
 
   /* FNV-1 hash each octet of the string */
   while (*s)
   {
     /* Multiply by the 64 bit FNV magic prime mod 2^64 */
-    hval *= (int64_t)0x100000001b3ULL;
+    hval *= (uint64_t)0x100000001b3ULL;
 
     /* XOR the bottom with the current octet */
-    hval ^= (int64_t)*s++;
+    hval ^= (uint64_t)*s++;
   }
 
   return hval;

--- a/src/generic.h
+++ b/src/generic.h
@@ -29,13 +29,13 @@ extern "C" {
 #include <libmseed.h>
 
 /* Key for B-trees */
-typedef int64_t Key;
+typedef uint64_t Key;
 
 extern int      SplitStreamID (char *streamid, char delim, int maxlength,
                                char *id1, char *id2, char *id3, char *id4, char *id5, char *id6,
                                char *type);
 extern hptime_t HPnow (void);
-extern int64_t  FVNhash64 (char *str);
+extern uint64_t FVNhash64 (const char *);
 extern int      KeyCompare (const void *a, const void *b);
 extern int      IsAllDigits (char *string);
 


### PR DESCRIPTION
The `int64_t hval = (int64_t)0xcbf29ce484222325ULL;` [C](https://en.wikipedia.org/wiki/C_(programming_language)) declaration results in a [C](https://en.wikipedia.org/wiki/C_(programming_language)) [undefined behaviour](https://en.wikipedia.org/wiki/Undefined_behavior) on my platform, because 0xcbf29ce484222325ULL is greater than INT64_MAX on my platform.

This [C](https://en.wikipedia.org/wiki/C_(programming_language)) [undefined behaviour](https://en.wikipedia.org/wiki/Undefined_behavior) causes `FVNhash64("NN_SSSSS_LL_CCC/MSEED")` to **erroneously** return -9223372036854775740 (i.e. 0x8000000000000044) **rather than** 18422540039308572745 (i.e. 0xffaa028f1765f849) on my platform, which prevents [ringserver](https://github.com/iris-edu/ringserver) from handling RingStream entries correctly on my platform.

This pull request fixes this [C](https://en.wikipedia.org/wiki/C_(programming_language)) [undefined behaviour](https://en.wikipedia.org/wiki/Undefined_behavior), so can you please **accept** this pull request?

Thank you very much for your efforts!