### PR TITLE
Issue 45 | Update Dockerfile to fix pcre compilation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,23 @@
 
 # Build ringserver in a separate container,
 # so resulting container does not include compiler tools
-FROM centos:7 as buildenv
-# Install compiler
-RUN yum install -y gcc make
+FROM debian:bookworm-slim as buildenv
+RUN apt update \
+    && apt upgrade -y \
+    && apt install -y --no-install-recommends \
+        build-essential \
+        automake \
+    && rm -rf /var/lib/apt/lists/*
+
 # Build executable
 COPY . /build
 RUN cd /build && CFLAGS="-O2" make
 
 # Build ringserver container
-FROM centos:7
-# Install updates
-RUN yum upgrade -y
+FROM debian:bookworm-slim
+RUN apt update \
+    && apt upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 # Copy executable and default config from build image
 COPY --from=buildenv /build/ringserver /ringserver
 COPY --from=buildenv /build/doc/ring.conf /ring.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt update \
     && apt install -y --no-install-recommends \
         build-essential \
         automake \
+        netbase \
     && rm -rf /var/lib/apt/lists/*
 
 # Build executable
@@ -28,6 +29,8 @@ RUN cd /build && CFLAGS="-O2" make
 FROM debian:bookworm-slim
 RUN apt update \
     && apt upgrade -y \
+    && apt install -y --no-install-recommends \
+        netbase \
     && rm -rf /var/lib/apt/lists/*
 # Copy executable and default config from build image
 COPY --from=buildenv /build/ringserver /ringserver


### PR DESCRIPTION
* Change base of Docker image from CentOS 7 to Debian Bookworm as CentOS is EOL'd.

* Include automake package to fix error compiling the pcre library.